### PR TITLE
Refactoring builder in linker

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ def supported_ruby_box? = RUBY_VERSION >= "4.0.0" && ENV["RUBY_BOX"] == "1" && d
 Rake::TestTask.new do |t|
   t.test_files = FileList['test/**/*_test.rb']
   if supported_ruby_box?
-    t.test_files = FileList['test/caotral/linker/fiddle_test.rb']
+    t.test_files = FileList['test/caotral/linker/integration/fiddle_test.rb']
   end
 end
 

--- a/lib/caotral/binary/elf/program_header.rb
+++ b/lib/caotral/binary/elf/program_header.rb
@@ -51,14 +51,19 @@ module Caotral
           self
         end
 
-        def type = PT_BY_V[@type.pack("C*").unpack1("L<")]
-        def flags = PF_BY_V[@flags.pack("C*").unpack1("L<")]
+        def type = PT_BY_V[type_value]
+        def flags = PF_BY_V[flags_value]
         def offset = @offset.pack("C*").unpack1("Q<")
         def filesz = @filesz.pack("C*").unpack1("Q<")
         def memsz = @memsz.pack("C*").unpack1("Q<")
         def vaddr = @vaddr.pack("C*").unpack1("Q<")
+        def paddr = @paddr.pack("C*").unpack1("Q<")
+        def align = @align.pack("C*").unpack1("Q<")
 
-        private def bytes = [@type, @flags, @offset, @vaddr, @paddr, @filesz, @memsz, @align]
+        private
+        def bytes = [@type, @flags, @offset, @vaddr, @paddr, @filesz, @memsz, @align]
+        def flags_value = @flags.pack("C*").unpack1("L<")
+        def type_value = @type.pack("C*").unpack1("L<")
       end
     end
   end

--- a/lib/caotral/binary/elf/program_header.rb
+++ b/lib/caotral/binary/elf/program_header.rb
@@ -25,6 +25,7 @@ module Caotral
           DYNAMIC: 2,
           INTERP: 3,
           PHDR: 6,
+          GNU_STACK: 0x6474e551,
         }.freeze
         PT_BY_V = PT.invert.freeze
         def initialize

--- a/lib/caotral/binary/elf/section.rb
+++ b/lib/caotral/binary/elf/section.rb
@@ -12,9 +12,22 @@ module Caotral
 
         def build
           return @body.build if @body.respond_to?(:build)
-          return @body.each_with_object(StringIO.new) { |b, io| io.write(b.build) }.string if @body.is_a?(Array)
+          if Array === @body
+            bytes = @body.flatten
+            return bytes.pack("C*") if bytes.all?(Integer)
+            return @body.each_with_object(StringIO.new) { |b, io| io.write(b.build) }.string
+          end
           return @body if @body.is_a?(String)
           "".b
+        end
+
+        def layout!(offset:)
+          size = build.bytesize
+          align = [@header.addralign.to_i, 1].max
+          offset = (offset + align - 1) / align * align
+          @header.set!(offset:, size:)
+
+          offset + size
         end
       end
     end

--- a/lib/caotral/binary/elf/section_header.rb
+++ b/lib/caotral/binary/elf/section_header.rb
@@ -53,6 +53,7 @@ module Caotral
         def addr = @addr.pack("C*").unpack1("Q<")
         def link = @link.pack("C*").unpack1("L<")
         def addralign = @addralign.pack("C*").unpack1("Q<")
+        def allocated? = (@flags.pack("C*").unpack1("Q<") & SHF[:ALLOC]) != 0
 
         private def bytes = [@name, @type, @flags, @addr, @offset, @size, @link, @info, @addralign, @entsize]
       end

--- a/lib/caotral/linker.rb
+++ b/lib/caotral/linker.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative "binary/elf/reader"
 require_relative "linker/builder"
+require_relative "linker/layout"
 require_relative "linker/writer"
 
 module Caotral

--- a/lib/caotral/linker.rb
+++ b/lib/caotral/linker.rb
@@ -14,7 +14,8 @@ module Caotral
       @inputs, @output, @linker = inputs, output, linker
       @options = linker_options
       @needed = needed
-      @executable, @debug, @shared, @pie = executable, debug, shared, pie
+      @executable = shared ? false : executable
+      @debug, @shared, @pie = debug, shared, pie
     end
 
     def link(inputs: @inputs, output: @output, debug: @debug, shared: @shared, executable: @executable, pie: @pie)
@@ -52,6 +53,8 @@ module Caotral
     def gcc_libpath = @gcc_libpath ||= File.dirname(Dir.glob("/usr/lib/gcc/x86_64-*/*/crtbegin.o").last)
 
     def to_elf(inputs: @inputs, output: @output, debug: @debug, shared: @shared, executable: @executable, pie: @pie, needed: @needed)
+      raise Caotral::Binary::ELF::Error, "disallow both mode: shared and PIE" if shared && pie
+
       elf_objs = inputs.map { |input| Caotral::Binary::ELF::Reader.new(input:, debug:).read }
       builder = Caotral::Linker::Builder.new(elf_objs:, debug:, shared:, executable:, pie:, needed:)
       builder.resolve_symbols

--- a/lib/caotral/linker/builder.rb
+++ b/lib/caotral/linker/builder.rb
@@ -36,7 +36,6 @@ module Caotral
           globals: { undefined: Set.new, defined: Hash.new }.freeze,
           weaks: Set.new,
         }.freeze
-        _mode!
         @linker_metadata = {}
       end
 
@@ -425,6 +424,9 @@ module Caotral
 
         @linker_metadata[:got_plt_offsets] = got_plt_offsets
         @linker_metadata[:pending_text_relocations] = rel_texts
+
+        Caotral::Linker::Layout.new(elf:, shared: @shared, executable: @executable, pie: @pie).apply!
+
         elf
       end
 
@@ -534,10 +536,6 @@ module Caotral
 
       def rel_type(section) = section.section_name&.start_with?(".rela.") ? 4 : 9
       def rel_entsize(section) = section.section_name&.start_with?(".rela.") ? 24 : 16
-      def _mode!
-        @executable = false if @shared
-        raise Caotral::Binary::ELF::Error, "disallow both mode: shared and PIE" if @pie && @shared
-      end
 
       def dynamic? = @shared || @pie
     end

--- a/lib/caotral/linker/error.rb
+++ b/lib/caotral/linker/error.rb
@@ -1,0 +1,8 @@
+require "caotral/binary/elf/error"
+
+module Caotral
+  class Linker
+    class Error < Caotral::Binary::ELF::Error
+    end
+  end
+end

--- a/lib/caotral/linker/layout.rb
+++ b/lib/caotral/linker/layout.rb
@@ -1,3 +1,5 @@
+require "caotral/binary/elf"
+
 module Caotral
   class Linker
     class Layout
@@ -20,11 +22,30 @@ module Caotral
       end
 
       private
-      def build_program_headers! = @elf.build_program_headers!
-      def layout_sections! = @elf.layout_sections!
-      def layout_section_headers! = @elf.layout_section_headers!
-      def finalize_program_headers! = @elf.finalize_program_headers!
-      def finalize_elf_header = @elf.finalize_heder!
+      def build_program_headers!
+        lph = build_program_header(type: 1)
+        iph = build_program_header(type: 3) if @elf.find_by_name(".interp")
+        dph = build_program_header(type: 2) if @elf.find_by_name(".dynamic")
+        pph = build_program_header(type: 6) if @pie
+        if @pie || @shared
+          gsph = build_program_header(
+            type: 0x6474e551,
+            flags: Caotral::Binary::ELF::ProgramHeader::PF[:RW]
+          )
+        end
+
+        @elf.program_headers.replace([pph, lph, iph, dph, gsph].compact)
+      end
+
+      def build_program_header(type:, flags: 0)
+        ph = Caotral::Binary::ELF::ProgramHeader.new
+        ph.set!(type:, flags:)
+        ph
+      end
+      def layout_sections! = nil
+      def layout_section_headers! = nil
+      def finalize_program_headers! = nil
+      def finalize_elf_header! = nil
     end
   end
 end

--- a/lib/caotral/linker/layout.rb
+++ b/lib/caotral/linker/layout.rb
@@ -70,7 +70,23 @@ module Caotral
         @file_offset += @elf.sections.sum { |section| section.header.build.bytesize }
       end
       def finalize_program_headers! = nil
-      def finalize_elf_header! = nil
+      def finalize_elf_header!
+        header = @elf.header
+        raise Caotral::Linker::Error, "Missing ELF header" unless header
+
+        type_sym = dynamic? ? :DYN : :EXEC
+        type = Caotral::Binary::ELF::Header::TYPE[type_sym]
+        phoffset, ehsize, phsize = 64, 64, 56
+
+        header.set!(
+          type:, phoffset:, ehsize:, phsize:,
+          phnum: @elf.program_headers.size,
+          shnum: @elf.sections.size,
+          shstrndx: @elf.index(".shstrtab"),
+          shoffset: @section_headers_offset
+        )
+      end
+      def dynamic? = @pie || @shared
     end
   end
 end

--- a/lib/caotral/linker/layout.rb
+++ b/lib/caotral/linker/layout.rb
@@ -1,0 +1,30 @@
+module Caotral
+  class Linker
+    class Layout
+      attr_reader :debug, :shared, :executable, :pie
+
+      def initialize(elf:, shared:, executable:, pie:)
+        @elf = elf
+        @shared = shared
+        @executable = executable
+        @pie = pie
+      end
+
+      def apply!
+        build_program_headers!
+        layout_sections!
+        layout_section_headers!
+        finalize_program_headers!
+        finalize_elf_header!
+        @elf
+      end
+
+      private
+      def build_program_headers! = @elf.build_program_headers!
+      def layout_sections! = @elf.layout_sections!
+      def layout_section_headers! = @elf.layout_section_headers!
+      def finalize_program_headers! = @elf.finalize_program_headers!
+      def finalize_elf_header = @elf.finalize_heder!
+    end
+  end
+end

--- a/lib/caotral/linker/layout.rb
+++ b/lib/caotral/linker/layout.rb
@@ -1,5 +1,7 @@
 require "caotral/binary/elf"
 
+require_relative "error"
+
 module Caotral
   class Linker
     class Layout
@@ -53,7 +55,20 @@ module Caotral
           @file_offset = section.layout!(offset: @file_offset)
         end
       end
-      def layout_section_headers! = nil
+      def layout_section_headers!
+        shstrtab = @elf.find_by_name(".shstrtab")
+        raise Caotral::Linker::Error, "Missing .shstrtab section" unless shstrtab
+        section_names = @elf.sections.map(&:section_name).map(&:to_s)
+        unless section_names.last == ".shstrtab"
+          raise Caotral::Linker::Error, "section header string table must be the last section"
+        end
+
+        shstrtab.body.names = section_names.uniq.join("\0") + "\0"
+        @file_offset = shstrtab.layout!(offset: @file_offset)
+
+        @section_headers_offset = @file_offset
+        @file_offset += @elf.sections.sum { |section| section.header.build.bytesize }
+      end
       def finalize_program_headers! = nil
       def finalize_elf_header! = nil
     end

--- a/lib/caotral/linker/layout.rb
+++ b/lib/caotral/linker/layout.rb
@@ -4,12 +4,11 @@ module Caotral
   class Linker
     class Layout
       attr_reader :debug, :shared, :executable, :pie
+      LATE_SECTIONS = ["", ".shstrtab"].freeze
 
       def initialize(elf:, shared:, executable:, pie:)
         @elf = elf
-        @shared = shared
-        @executable = executable
-        @pie = pie
+        @shared, @executable, @pie, @file_offset = shared, executable, pie, 0
       end
 
       def apply!
@@ -42,7 +41,18 @@ module Caotral
         ph.set!(type:, flags:)
         ph
       end
-      def layout_sections! = nil
+      def layout_sections!
+        header_end = (64 + (@elf.program_headers.size * 56))
+        first_section = @elf.sections.find { |s| s.section_name && !LATE_SECTIONS.include?(s.section_name) }
+        first_offset = first_section&.header&.offset.to_i || 0
+        @file_offset = [header_end, first_offset].max
+
+        @elf.sections.each do |section|
+          next if section.section_name.nil?
+          next if LATE_SECTIONS.include?(section.section_name)
+          @file_offset = section.layout!(offset: @file_offset)
+        end
+      end
       def layout_section_headers! = nil
       def finalize_program_headers! = nil
       def finalize_elf_header! = nil

--- a/lib/caotral/linker/layout.rb
+++ b/lib/caotral/linker/layout.rb
@@ -78,7 +78,57 @@ module Caotral
         @section_headers_offset = @file_offset
         @file_offset += @elf.sections.sum { |section| section.header.build.bytesize }
       end
-      def finalize_program_headers! = nil
+      def finalize_program_headers!
+        @elf.program_headers.each do |ph|
+          case ph.type
+          when :PHDR
+            offset, vaddr, paddr, align = 64, 64, 64, 8
+            filesz = @elf.program_headers.size * 56
+            memsz = filesz
+            flags = Caotral::Binary::ELF::ProgramHeader::PF[:R]
+          when :LOAD
+            text = @elf.find_by_name(".text")
+            next unless text
+
+            allocated_sections = @elf.sections.select { |s| s.header.allocated? }
+            segment_start = @pie ? 0 : text.header.offset
+            segment_end = allocated_sections.map { |s| s.header.offset + s.header.size }.max
+
+            next unless segment_end
+
+            offset = segment_start
+            vaddr = @pie ? 0 : text.header.addr
+            paddr = vaddr
+            filesz = segment_end - segment_start
+            memsz = filesz
+            flags = Caotral::Binary::ELF::ProgramHeader::PF[:RWX]
+            align = 0x1000
+          when :INTERP
+            interp = @elf.find_by_name(".interp")
+            raise Caotral::Linker::Error, "Missing .interp section" unless interp
+            offset, vaddr, paddr, align = interp.header.offset, 0, 0, 1
+            filesz = interp.header.size
+            memsz = filesz
+            flags = Caotral::Binary::ELF::ProgramHeader::PF[:R]
+          when :DYNAMIC
+            dynamic = @elf.find_by_name(".dynamic")
+            raise Caotral::Linker::Error, "Missing .dynamic section" unless dynamic
+            header = dynamic.header
+            offset, vaddr, paddr, align = header.offset, header.addr, header.addr, header.addralign
+            filesz = header.size
+            memsz = filesz
+            flags = Caotral::Binary::ELF::ProgramHeader::PF[:R]
+          when :GNU_STACK
+            offset, vaddr, paddr, align = 0, 0, 0, 0
+            filesz = 0
+            memsz = 0
+            flags = Caotral::Binary::ELF::ProgramHeader::PF[:RW]
+          else
+            raise Caotral::Linker::Error, "Not Implemented: #{ph.type} program header layout"
+          end
+          ph.set!(offset:, vaddr:, paddr:, filesz:, memsz:, flags:, align:)
+        end
+      end
       def finalize_elf_header!
         header = @elf.header
         raise Caotral::Linker::Error, "Missing ELF header" unless header

--- a/lib/caotral/linker/layout.rb
+++ b/lib/caotral/linker/layout.rb
@@ -54,6 +54,15 @@ module Caotral
           next if LATE_SECTIONS.include?(section.section_name)
           @file_offset = section.layout!(offset: @file_offset)
         end
+
+        text = @elf.find_by_name(".text")
+        return unless text
+        @elf.sections.each do |section|
+          next unless section.header.allocated?
+
+          addr = text.header.addr + (section.header.offset - text.header.offset)
+          section.header.set!(addr:)
+        end
       end
       def layout_section_headers!
         shstrtab = @elf.find_by_name(".shstrtab")

--- a/lib/caotral/linker/writer.rb
+++ b/lib/caotral/linker/writer.rb
@@ -7,14 +7,14 @@ module Caotral
       REL_TYPES = Caotral::Binary::ELF::Section::Rel::TYPES.freeze
       ALLOW_RELOCATION_TYPES = [REL_TYPES[:AMD64_PC32], REL_TYPES[:AMD64_PLT32]].freeze
       RELOCATION_SECTION_NAMES = [".rela.text", ".rela.dyn", ".rela.data", ".rela.plt"].freeze
-      attr_reader :elf_obj, :output, :entry, :debug, :got_plt_offsets, :pending_text_relocations
+      attr_reader :elf_obj, :output, :entry, :debug, :got_plt_offsets, :pending_text_relocations, :program_headers
       def self.write!(elf_obj:, output:, metadata: nil, entry: nil, debug: false, executable: true, shared: false)
         new(elf_obj:, output:, metadata:, entry:, debug:, shared:, executable:).write
       end
 
       def initialize(elf_obj:, output:, metadata: nil, entry: nil, debug: false, executable: true, shared: false, pie: false)
         @elf_obj, @output, @entry, @debug, @executable, @shared, @pie = elf_obj, output, entry, debug, executable, shared, pie
-        @program_headers = []
+        @program_headers = elf_obj.program_headers
         @write_sections = elf_obj.sections
         @got_plt_offsets = {}
         @got_plt_offsets = metadata.fetch(:got_plt_offsets, {}) if metadata
@@ -433,33 +433,6 @@ module Caotral
       def dynamic? = (@shared || @pie)
 
       def dynamic_tables = Caotral::Binary::ELF::Section::Dynamic::TAG_TYPES
-      def program_headers
-        return @program_headers unless @program_headers.empty?
-        # PT_LOAD
-        lph = Caotral::Binary::ELF::ProgramHeader.new
-        lph.set!(type: 1)
-        # PT_INTERP
-        if interp_section
-          iph = Caotral::Binary::ELF::ProgramHeader.new
-          iph.set!(type: 3)
-        end
-        # PT_DYNAMIC
-        if dynamic_section
-          dph = Caotral::Binary::ELF::ProgramHeader.new
-          dph.set!(type: 2)
-        end
-        # PT_PHDR
-        if @pie
-          pph = Caotral::Binary::ELF::ProgramHeader.new
-          pph.set!(type: 6)
-        end
-        # ruby's dlopen support
-        if dynamic?
-          gsph = Caotral::Binary::ELF::ProgramHeader.new
-          gsph.set!(type: 0x6474e551, flags: program_header_flags(:RW))
-        end
-        @program_headers = [pph, lph, iph, dph, gsph].compact
-      end
       def pie_program_header = @pie_program_header ||= program_headers.find { |ph| ph.type == :PHDR }
       def load_program_header = @load_program_header ||= program_headers.find { |ph| ph.type == :LOAD }
       def interp_program_header = @interp_program_header ||= program_headers.find { |ph| ph.type == :INTERP }

--- a/test/caotral/linker/integration/fiddle_test.rb
+++ b/test/caotral/linker/integration/fiddle_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../test_suite"
+require_relative "../../../test_suite"
 
 class Caotral::Linker::FiddleMethodTest < Test::Unit::TestCase
   include TestProcessHelper

--- a/test/caotral/linker/integration/gotpc_call_test.rb
+++ b/test/caotral/linker/integration/gotpc_call_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../test_suite"
+require_relative "../../../test_suite"
 
 class Caotral::Linker::GOTPCRelTest < Test::Unit::TestCase
   include TestProcessHelper

--- a/test/caotral/linker/integration/multi_link_test.rb
+++ b/test/caotral/linker/integration/multi_link_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../test_suite"
+require_relative "../../../test_suite"
 
 class Caotral::Linker::MultiFileLinkingTest < Test::Unit::TestCase
   include TestProcessHelper

--- a/test/caotral/linker/integration/needed_test.rb
+++ b/test/caotral/linker/integration/needed_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../test_suite"
+require_relative "../../../test_suite"
 
 class LinkerNeededTest < Test::Unit::TestCase
   include TestProcessHelper

--- a/test/caotral/linker/integration/pie_object_test.rb
+++ b/test/caotral/linker/integration/pie_object_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../test_suite"
+require_relative "../../../test_suite"
 
 class Caotral::Linker::PIEObjectLinkingTest < Test::Unit::TestCase
   include TestProcessHelper

--- a/test/caotral/linker/integration/plt_call_test.rb
+++ b/test/caotral/linker/integration/plt_call_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../test_suite"
+require_relative "../../../test_suite"
 
 class Caotral::Linker::PLTCallTest < Test::Unit::TestCase
   def setup

--- a/test/caotral/linker/integration/shared_object_test.rb
+++ b/test/caotral/linker/integration/shared_object_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../test_suite"
+require_relative "../../../test_suite"
 
 class Caotral::Linker::SharedObjectLinkingTest < Test::Unit::TestCase
   include TestProcessHelper

--- a/test/caotral/linker/integration/symbol_remap_test.rb
+++ b/test/caotral/linker/integration/symbol_remap_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../test_suite"
+require_relative "../../../test_suite"
 
 class Caotral::Linker::SymbolRemapTest < Test::Unit::TestCase
   include TestProcessHelper

--- a/test/caotral/linker/layout_test.rb
+++ b/test/caotral/linker/layout_test.rb
@@ -3,14 +3,23 @@ require_relative "../../test_suite"
 class Caotral::Linker::LayoutTest < Test::Unit::TestCase
   attr_reader :elf
   def setup = (@elf = Caotral::Binary::ELF.new)
-  def test_layout
+  def test_layout_without_sections
     layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: true, pie: false)
     layout.apply!
     assert_equal(1, elf.program_headers.size)
     assert_equal(:LOAD, elf.program_headers[0].type)
   end
+  def test_layout_with_text
+    text_section = build_dummy_section(name: ".text", offset: 0x1000)
+    elf.sections << text_section
+    layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: true, pie: false)
+    layout.apply!
+    assert_equal(1, elf.program_headers.size)
+    assert_equal(:LOAD, elf.program_headers[0].type)
+    assert_equal(0x1000, text_section.header.offset)
+  end
   def test_layout_with_pie
-    elf.sections << build_dummy_section(".interp")
+    elf.sections << build_dummy_section(name: ".interp")
     layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: false, pie: true)
     layout.apply!
     assert_equal(4, elf.program_headers.size)
@@ -21,7 +30,7 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
   end
 
   def test_layout_with_dynamic
-    elf.sections << build_dummy_section(".dynamic")
+    elf.sections << build_dummy_section(name: ".dynamic")
     layout = Caotral::Linker::Layout.new(elf:, shared: true, executable: false, pie: false)
     layout.apply!
     assert_equal(3, elf.program_headers.size)
@@ -30,12 +39,25 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
     assert_equal(:GNU_STACK, elf.program_headers[2].type)
   end
 
+  def test_layout_sections
+    text = build_dummy_section(name: ".text", body: "abc".b, addralign: 16)
+    data = build_dummy_section(name: ".data", body: "def".b, addralign: 8)
+    elf.sections << text
+    elf.sections << data
+    layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: true, pie: false)
+    layout.apply!
+
+    assert_equal(128, text.header.offset)
+    assert_equal(3, text.header.size)
+    assert_equal(136, data.header.offset)
+    assert_equal(3, data.header.size)
+  end
+
   private
-  def build_dummy_section(name)
-    Caotral::Binary::ELF::Section.new(
-      header: Caotral::Binary::ELF::SectionHeader.new,
-      body: "".b,
-      section_name: name
-    )
+  def build_dummy_section(name:, body: "".b, addralign: 1, offset: 0)
+    header = Caotral::Binary::ELF::SectionHeader.new
+    header.set!(addralign:, offset:)
+
+    Caotral::Binary::ELF::Section.new(header:, body:, section_name: name)
   end
 end

--- a/test/caotral/linker/layout_test.rb
+++ b/test/caotral/linker/layout_test.rb
@@ -1,17 +1,32 @@
 require_relative "../../test_suite"
 
 class Caotral::Linker::LayoutTest < Test::Unit::TestCase
-  attr_reader :elf
-  def setup = (@elf = Caotral::Binary::ELF.new)
+  attr_reader :elf, :shstrtab
+  def setup
+    @elf = Caotral::Binary::ELF.new
+    @shstrtab = build_dummy_section(
+      name: ".shstrtab",
+      body: Caotral::Binary::ELF::Section::Strtab.new
+    )
+  end
+
   def test_layout_without_sections
+    layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: true, pie: false)
+    assert_raise(Caotral::Linker::Error) { layout.apply! }
+  end
+
+  def test_layout_minimal_section
+    elf.sections << shstrtab
     layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: true, pie: false)
     layout.apply!
     assert_equal(1, elf.program_headers.size)
     assert_equal(:LOAD, elf.program_headers[0].type)
   end
+
   def test_layout_with_text
     text_section = build_dummy_section(name: ".text", offset: 0x1000)
     elf.sections << text_section
+    elf.sections << shstrtab
     layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: true, pie: false)
     layout.apply!
     assert_equal(1, elf.program_headers.size)
@@ -20,6 +35,7 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
   end
   def test_layout_with_pie
     elf.sections << build_dummy_section(name: ".interp")
+    elf.sections << shstrtab
     layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: false, pie: true)
     layout.apply!
     assert_equal(4, elf.program_headers.size)
@@ -31,6 +47,7 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
 
   def test_layout_with_dynamic
     elf.sections << build_dummy_section(name: ".dynamic")
+    elf.sections << shstrtab
     layout = Caotral::Linker::Layout.new(elf:, shared: true, executable: false, pie: false)
     layout.apply!
     assert_equal(3, elf.program_headers.size)
@@ -44,6 +61,7 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
     data = build_dummy_section(name: ".data", body: "def".b, addralign: 8)
     elf.sections << text
     elf.sections << data
+    elf.sections << shstrtab
     layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: true, pie: false)
     layout.apply!
 
@@ -51,6 +69,9 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
     assert_equal(3, text.header.size)
     assert_equal(136, data.header.offset)
     assert_equal(3, data.header.size)
+    assert_equal(139, shstrtab.header.offset)
+    assert_equal(22, shstrtab.header.size)
+    assert_equal(".text\0.data\0.shstrtab\0", shstrtab.body.names)
   end
 
   private

--- a/test/caotral/linker/layout_test.rb
+++ b/test/caotral/linker/layout_test.rb
@@ -63,7 +63,14 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
   end
 
   def test_layout_with_dynamic
-    elf.sections << build_dummy_section(name: ".dynamic")
+    dynamic = build_dummy_section(
+      name: ".dynamic",
+      body: "dynamic".b,
+      addralign: 8,
+      addr: 0x3000,
+      flags: flags(:data)
+    )
+    elf.sections << dynamic
     elf.sections << shstrtab
     layout = Caotral::Linker::Layout.new(elf:, shared: true, executable: false, pie: false)
     layout.apply!
@@ -72,6 +79,13 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
     assert_equal(:DYNAMIC, elf.program_headers[1].type)
     assert_equal(:GNU_STACK, elf.program_headers[2].type)
     assert_equal(:DYN, elf.header.type)
+    assert_equal(dynamic.header.offset, elf.program_headers[1].offset)
+    assert_equal(dynamic.header.addr, elf.program_headers[1].vaddr)
+    assert_equal(dynamic.header.addr, elf.program_headers[1].paddr)
+    assert_equal(dynamic.header.size, elf.program_headers[1].filesz)
+    assert_equal(dynamic.header.size, elf.program_headers[1].memsz)
+    assert_equal(dynamic.header.addralign, elf.program_headers[1].align)
+    assert_equal(:R, elf.program_headers[1].flags)
   end
 
   def test_layout_sections
@@ -92,6 +106,7 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
     assert_equal(".text\0.data\0.shstrtab\0", shstrtab.body.names)
     assert_equal(0x10, text.header.addr)
     assert_equal(0x18, data.header.addr)
+    assert_equal(text.header.offset, elf.program_headers[0].offset)
   end
 
   private

--- a/test/caotral/linker/layout_test.rb
+++ b/test/caotral/linker/layout_test.rb
@@ -40,14 +40,14 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
   end
 
   def test_layout_with_text
-    text_section = build_dummy_section(name: ".text", offset: 0x1000)
-    elf.sections << text_section
+    text = build_dummy_section(name: ".text", offset: 0x1000)
+    elf.sections << text
     elf.sections << shstrtab
     layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: true, pie: false)
     layout.apply!
     assert_equal(1, elf.program_headers.size)
     assert_equal(:LOAD, elf.program_headers[0].type)
-    assert_equal(0x1000, text_section.header.offset)
+    assert_equal(0x1000, text.header.offset)
   end
   def test_layout_with_pie
     elf.sections << build_dummy_section(name: ".interp")
@@ -75,8 +75,8 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
   end
 
   def test_layout_sections
-    text = build_dummy_section(name: ".text", body: "abc".b, addralign: 16)
-    data = build_dummy_section(name: ".data", body: "def".b, addralign: 8)
+    text = build_dummy_section(name: ".text", body: "abc".b, addralign: 16, flags: flags(:text), addr: 0x10)
+    data = build_dummy_section(name: ".data", body: "def".b, addralign: 8, flags: flags(:data))
     elf.sections << text
     elf.sections << data
     elf.sections << shstrtab
@@ -90,13 +90,26 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
     assert_equal(139, shstrtab.header.offset)
     assert_equal(22, shstrtab.header.size)
     assert_equal(".text\0.data\0.shstrtab\0", shstrtab.body.names)
+    assert_equal(0x10, text.header.addr)
+    assert_equal(0x18, data.header.addr)
   end
 
   private
-  def build_dummy_section(name:, body: "".b, addralign: 1, offset: 0)
+  def build_dummy_section(name:, body: "".b, addralign: 1, offset: 0, flags: 0, addr: 0)
     header = Caotral::Binary::ELF::SectionHeader.new
-    header.set!(addralign:, offset:)
+    header.set!(addralign:, offset:, flags:, addr:)
 
     Caotral::Binary::ELF::Section.new(header:, body:, section_name: name)
+  end
+
+  def flags(type = nil)
+    case type
+    when :text
+      Caotral::Binary::ELF::SectionHeader::SHF[:ALLOC] | Caotral::Binary::ELF::SectionHeader::SHF[:EXECINSTR]
+    when :data
+      Caotral::Binary::ELF::SectionHeader::SHF[:ALLOC] | Caotral::Binary::ELF::SectionHeader::SHF[:WRITE]
+    else
+      0
+    end
   end
 end

--- a/test/caotral/linker/layout_test.rb
+++ b/test/caotral/linker/layout_test.rb
@@ -1,0 +1,41 @@
+require_relative "../../test_suite"
+
+class Caotral::Linker::LayoutTest < Test::Unit::TestCase
+  attr_reader :elf
+  def setup = (@elf = Caotral::Binary::ELF.new)
+  def test_layout
+    layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: true, pie: false)
+    layout.apply!
+    assert_equal(1, elf.program_headers.size)
+    assert_equal(:LOAD, elf.program_headers[0].type)
+  end
+  def test_layout_with_pie
+    elf.sections << build_dummy_section(".interp")
+    layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: false, pie: true)
+    layout.apply!
+    assert_equal(4, elf.program_headers.size)
+    assert_equal(:PHDR, elf.program_headers[0].type)
+    assert_equal(:LOAD, elf.program_headers[1].type)
+    assert_equal(:INTERP, elf.program_headers[2].type)
+    assert_equal(:GNU_STACK, elf.program_headers[3].type)
+  end
+
+  def test_layout_with_dynamic
+    elf.sections << build_dummy_section(".dynamic")
+    layout = Caotral::Linker::Layout.new(elf:, shared: true, executable: false, pie: false)
+    layout.apply!
+    assert_equal(3, elf.program_headers.size)
+    assert_equal(:LOAD, elf.program_headers[0].type)
+    assert_equal(:DYNAMIC, elf.program_headers[1].type)
+    assert_equal(:GNU_STACK, elf.program_headers[2].type)
+  end
+
+  private
+  def build_dummy_section(name)
+    Caotral::Binary::ELF::Section.new(
+      header: Caotral::Binary::ELF::SectionHeader.new,
+      body: "".b,
+      section_name: name
+    )
+  end
+end

--- a/test/caotral/linker/layout_test.rb
+++ b/test/caotral/linker/layout_test.rb
@@ -8,9 +8,18 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
       name: ".shstrtab",
       body: Caotral::Binary::ELF::Section::Strtab.new
     )
+    @elf.header = Caotral::Binary::ELF::Header.new
   end
 
   def test_layout_without_sections
+    layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: true, pie: false)
+    assert_raise(Caotral::Linker::Error) { layout.apply! }
+  end
+
+  def test_layout_without_header
+    elf.sections << shstrtab
+    elf.header = nil
+
     layout = Caotral::Linker::Layout.new(elf:, shared: false, executable: true, pie: false)
     assert_raise(Caotral::Linker::Error) { layout.apply! }
   end
@@ -21,6 +30,13 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
     layout.apply!
     assert_equal(1, elf.program_headers.size)
     assert_equal(:LOAD, elf.program_headers[0].type)
+    assert_equal(:EXEC, elf.header.type)
+    assert_equal(64, elf.header.phoffset)
+    assert_equal(56, elf.header.phsize)
+    assert_equal(1, elf.header.phnum)
+    assert_equal(130, elf.header.shoffset)
+    assert_equal(1, elf.header.shnum)
+    assert_equal(0, elf.header.shstrndx)
   end
 
   def test_layout_with_text
@@ -43,6 +59,7 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
     assert_equal(:LOAD, elf.program_headers[1].type)
     assert_equal(:INTERP, elf.program_headers[2].type)
     assert_equal(:GNU_STACK, elf.program_headers[3].type)
+    assert_equal(:DYN, elf.header.type)
   end
 
   def test_layout_with_dynamic
@@ -54,6 +71,7 @@ class Caotral::Linker::LayoutTest < Test::Unit::TestCase
     assert_equal(:LOAD, elf.program_headers[0].type)
     assert_equal(:DYNAMIC, elf.program_headers[1].type)
     assert_equal(:GNU_STACK, elf.program_headers[2].type)
+    assert_equal(:DYN, elf.header.type)
   end
 
   def test_layout_sections

--- a/test/caotral/linker/writer_test.rb
+++ b/test/caotral/linker/writer_test.rb
@@ -32,8 +32,11 @@ class Caotral::Linker::WriterTest < Test::Unit::TestCase
 
   def test_relocation_write_and_execute
     IO.popen("gcc -c -fno-pic -fno-pie -o relocatable.o sample/C/rel_text.c").close
-    elf_obj = Caotral::Binary::ELF::Reader.read!(input: "relocatable.o", debug: false)
-    Caotral::Linker::Writer.write!(elf_obj:, output: "relocated_exec", debug: false)
+    input_elf = Caotral::Binary::ELF::Reader.read!(input: "relocatable.o", debug: false)
+    builder = Caotral::Linker::Builder.new(elf_objs: [input_elf], debug: false)
+    builder.resolve_symbols
+    elf_obj = builder.build
+    Caotral::Linker::Writer.write!(elf_obj:, output: "relocated_exec", debug: false, metadata: builder.linker_metadata)
     File.chmod(0755, "./relocated_exec")
     IO.popen("./relocated_exec").close
     exit_code, _handle_code = check_process($?.to_i)


### PR DESCRIPTION
## Summary

- Split linker processing into distinct Builder, Layout, Finalizer, and Writer stages.
- Move ELF section placement, section header table layout, ELF header fields, and program header construction into Layout.
- Move layout-dependent relocation, dynamic section, PLT/GOT, and section header updates into Finalizer.
- Reduce Writer to serializing an already laid-out and finalized ELF object.
- Orchestrate Builder → Layout → Finalizer → Writer from Linker.
- Reorganize linker integration tests and add focused Layout coverage.

## Testing

All tests pass.

- `rake test`
- `rake steep:check`