### PR TITLE
Support bss sections

### DIFF
--- a/lib/caotral/binary/elf/section.rb
+++ b/lib/caotral/binary/elf/section.rb
@@ -22,13 +22,18 @@ module Caotral
         end
 
         def layout!(offset:)
-          size = build.bytesize
+          size = file_size
           align = [@header.addralign.to_i, 1].max
           offset = (offset + align - 1) / align * align
-          @header.set!(offset:, size:)
-
-          offset + size
+          if header.nobits?
+            header.set!(offset:)
+          else
+            header.set!(offset:, size:)
+          end
+          offset + file_size
         end
+        def file_size = header.nobits? ? 0 : build.bytesize
+        def memory_size = header.nobits? ? header.size : build.bytesize
       end
     end
   end

--- a/lib/caotral/binary/elf/section_header.rb
+++ b/lib/caotral/binary/elf/section_header.rb
@@ -56,6 +56,7 @@ module Caotral
         def allocated? = (@flags.pack("C*").unpack1("Q<") & SHF[:ALLOC]) != 0
         def writable? = (@flags.pack("C*").unpack1("Q<") & SHF[:WRITE]) != 0
         def execinstr? = (@flags.pack("C*").unpack1("Q<") & SHF[:EXECINSTR]) != 0
+        def nobits? = type == :nobits
 
         private def bytes = [@name, @type, @flags, @addr, @offset, @size, @link, @info, @addralign, @entsize]
       end

--- a/lib/caotral/linker/builder.rb
+++ b/lib/caotral/linker/builder.rb
@@ -88,6 +88,12 @@ module Caotral
           section_name: ".strtab",
           header: Caotral::Binary::ELF::SectionHeader.new
         )
+        bss_section = Caotral::Binary::ELF::Section.new(
+          body: nil,
+          section_name: ".bss",
+          header: Caotral::Binary::ELF::SectionHeader.new
+                    .set!(type: SHT[:nobits], flags: SHF[:ALLOC] | SHF[:WRITE], addralign: 8)
+        )
         symtab_section = Caotral::Binary::ELF::Section.new(
           body: [],
           section_name: ".symtab",
@@ -123,10 +129,12 @@ module Caotral
         strtab_names = []
         text_offsets = {}
         rodata_offsets = {}
+        bss_offsets = {}
         data_offsets = {}
         got_plt_offsets = {}
         text_offset = 0
         rodata_offset = 0
+        bss_offset = 0
         data_offset = 0
         got_plt_offset = 24
         sym_by_elf = Hash.new { |h, k| h[k] = [] }
@@ -154,6 +162,11 @@ module Caotral
             data_offsets[elf_obj.object_id] = data_offset
             data_offset += data.body.bytesize
           end
+          bss = elf_obj.find_by_name(".bss")
+          unless bss.nil?
+            bss_offsets[elf_obj.object_id] = bss_offset
+            bss_offset += bss.memory_size
+          end
           strtab = elf_obj.find_by_name(".strtab")
           strtab.body.names.split("\0").each { |name| strtab_names << name } unless strtab.nil?
           symtab = elf_obj.find_by_name(".symtab")
@@ -161,6 +174,7 @@ module Caotral
           unless symtab.nil?
             base_index = symtab_section.body.size
             text_index = elf_obj.sections.index(text) unless text.nil?
+            bss_index = elf_obj.sections.index(bss) unless bss.nil?
             data_index = elf_obj.sections.index(data) unless data.nil?
             rodata_index = elf_obj.sections.index(rodata) unless rodata.nil?
 
@@ -169,6 +183,7 @@ module Caotral
               name, info, other, shndx, value, size = st.build.unpack("L<CCS<Q<Q<")
               sym_by_elf[elf_obj] << sym
               value += text_offsets.fetch(elf_obj.object_id, 0) if shndx == text_index
+              value += bss_offsets.fetch(elf_obj.object_id, 0) if shndx == bss_index
               value += data_offsets.fetch(elf_obj.object_id, 0) if shndx == data_index
               value += rodata_offsets.fetch(elf_obj.object_id, 0) if shndx == rodata_index
               sym.set!(name:, info:, other:, shndx:, value:, size:)
@@ -278,7 +293,6 @@ module Caotral
           sections << plt_section
           sections << got_plt_section
         end
-        sections << strtab_section
         text_index = sections.index(text_section)
         symtab_section.body.each do |sym|
           next if sym.shndx == 0
@@ -297,12 +311,10 @@ module Caotral
         symtab_section.header.set!(
           type: 2,
           flags: 0,
-          link: elf.sections.index(strtab_section),
           info: local_count,
           addralign: 8,
           entsize: 24
         )
-
         sections += build_pie_sections if @pie
         if dynamic?
           @needed.each { |lib| dynstr.body.names += lib + "\0" if dynstr.body.offset_of(lib).nil? }
@@ -344,7 +356,9 @@ module Caotral
 
           sections << dynamic_section
         end
+        sections << bss_section if bss_offset > 0
         sections << symtab_section
+        sections << strtab_section
 
         rel_sections.each { |s| sections << s.dup }
 
@@ -356,6 +370,8 @@ module Caotral
         )
 
         sections << shstrtab_section
+
+        bss_section.header.set!(size: bss_offset)
 
         shstrtab_section_names = [*sections.map(&:section_name), "\0"].join("\0")
         shstrtab_section.body.names = shstrtab_section_names

--- a/lib/caotral/linker/builder.rb
+++ b/lib/caotral/linker/builder.rb
@@ -136,6 +136,7 @@ module Caotral
         text_offset = 0
         rodata_offset = 0
         bss_offset = 0
+        bss_present = false
         bss_addralign = 1
         data_offset = 0
         got_plt_offset = 24
@@ -166,6 +167,7 @@ module Caotral
           end
           bss = elf_obj.find_by_name(".bss")
           unless bss.nil?
+            bss_present = true
             alignment = [bss.header.addralign, 1].max
             bss_offset = align_up(bss_offset, alignment)
             bss_addralign = [bss_addralign, alignment].compact.max
@@ -362,7 +364,7 @@ module Caotral
 
           sections << dynamic_section
         end
-        sections << bss_section if bss_offset > 0
+        sections << bss_section if bss_present
         sections << symtab_section
         sections << strtab_section
 

--- a/lib/caotral/linker/builder.rb
+++ b/lib/caotral/linker/builder.rb
@@ -125,6 +125,7 @@ module Caotral
         rel_sections = []
         rel_texts = []
         pending_relative_relocations = []
+        dynamic_symbol_pairs = []
         elf.header = elf_obj.header.dup
         strtab_names = []
         text_offsets = {}
@@ -135,6 +136,7 @@ module Caotral
         text_offset = 0
         rodata_offset = 0
         bss_offset = 0
+        bss_addralign = 1
         data_offset = 0
         got_plt_offset = 24
         sym_by_elf = Hash.new { |h, k| h[k] = [] }
@@ -164,6 +166,9 @@ module Caotral
           end
           bss = elf_obj.find_by_name(".bss")
           unless bss.nil?
+            alignment = [bss.header.addralign, 1].max
+            bss_offset = align_up(bss_offset, alignment)
+            bss_addralign = [bss_addralign, alignment].compact.max
             bss_offsets[elf_obj.object_id] = bss_offset
             bss_offset += bss.memory_size
           end
@@ -338,6 +343,7 @@ module Caotral
               name = dynstr.body.offset_of(copy_sym.name_string)
             end
             copy_sym.name_string = sym.name_string
+            dynamic_symbol_pairs << [copy_sym, sym]
             dynsym.body << copy_sym.set!(name:, shndx:, value: sym.value)
           end
           hash = Caotral::Binary::ELF::Section::Hash.new(nchain: dynsym.body.size)
@@ -371,7 +377,7 @@ module Caotral
 
         sections << shstrtab_section
 
-        bss_section.header.set!(size: bss_offset)
+        bss_section.header.set!(size: bss_offset, addralign: bss_addralign)
 
         shstrtab_section_names = [*sections.map(&:section_name), "\0"].join("\0")
         shstrtab_section.body.names = shstrtab_section_names
@@ -391,6 +397,8 @@ module Caotral
             sym.set!(shndx:)
           end
         end
+
+        dynamic_symbol_pairs.each { |copy_sym, sym| copy_sym.set!(shndx: sym.shndx) }
 
         defined_global_index = {}
         symtab_section.body.each_with_index do |sym, index|
@@ -551,6 +559,7 @@ module Caotral
 
       def rel_type(section) = section.section_name&.start_with?(".rela.") ? 4 : 9
       def rel_entsize(section) = section.section_name&.start_with?(".rela.") ? 24 : 16
+      def align_up(val, align) = (val + align - 1) / align * align
 
       def dynamic? = @shared || @pie
     end

--- a/lib/caotral/linker/layout.rb
+++ b/lib/caotral/linker/layout.rb
@@ -118,15 +118,23 @@ module Caotral
           when :LOAD
             allocated_sections = @load_sections[ph.flags]
 
-            section_end = allocated_sections.map { |s| s.header.offset + s.header.size }.max
+            memory_end = allocated_sections.map { |s| s.header.offset + s.memory_size }.max
+            file_end = allocated_sections
+                         .reject { |s| s.header.nobits? }
+                         .map { |s| s.header.offset + s.file_size }.max
             segment_start = ph.flags == :R ? 0 : allocated_sections.map { |s| s.header.offset }.min
-            segment_end = ph.flags == :R ? [header_end, section_end].compact.max : section_end
+            if ph.flags == :R
+              memory_end = [header_end, memory_end].compact.max
+              file_end = [header_end, file_end].compact.max
+            end
+            memory_end ||= segment_start
+            file_end ||= segment_start
 
             offset = segment_start
             vaddr = @load_bias + offset
             paddr = vaddr
-            filesz = segment_end - segment_start
-            memsz = filesz
+            filesz = file_end - segment_start
+            memsz = memory_end - segment_start
             flags = PF[ph.flags]
             align = LOAD_ALIGNMENT
           when :INTERP

--- a/sample/assembler/bss.s
+++ b/sample/assembler/bss.s
@@ -1,0 +1,16 @@
+.section .bss
+.balign 8
+.globl value
+.type value, @object
+.size value, 8
+value:
+  .zero 8
+
+.text
+.globl _start
+.type _start, @function
+_start:
+  movq $42, value(%rip)
+  movq value(%rip), %rdi
+  movq $60, %rax
+  syscall

--- a/sample/assembler/bss_initialize_zero.s
+++ b/sample/assembler/bss_initialize_zero.s
@@ -1,0 +1,27 @@
+.section .bss
+.balign 8
+.zero 24
+
+.globl value
+.type value, @object
+.size value, 8
+value:
+  .zero 8
+
+.text
+.globl _start
+.type _start, @function
+_start:
+  cmpq $0, value(%rip)
+  jne .Lnot_zero
+
+  movq $42, value(%rip)
+  movq value(%rip), %rdi
+  jmp .Lexit
+
+.Lnot_zero:
+  movq $1, %rdi
+
+.Lexit:
+  movq $60, %rax
+  syscall

--- a/sample/assembler/empty_bss.s
+++ b/sample/assembler/empty_bss.s
@@ -1,0 +1,15 @@
+.section .bss
+.balign 8
+.globl value
+.type value, @object
+.size value, 0
+value:
+
+.text
+.globl _start
+.type _start, @function
+_start:
+  movq $42, value(%rip)
+  movq value(%rip), %rdi
+  movq $60, %rax
+  syscall

--- a/sample/assembler/two_bss_sections.s
+++ b/sample/assembler/two_bss_sections.s
@@ -1,0 +1,7 @@
+.section .bss
+.balign 16
+.globl aligned_value
+.type aligned_value, @object
+.size aligned_value, 16
+aligned_value:
+  .zero 16

--- a/sig/caotral/binary/elf/section.rbs
+++ b/sig/caotral/binary/elf/section.rbs
@@ -8,4 +8,7 @@ class Caotral::Binary::ELF::Section
     body: untyped,
     section_name: String?
   ) -> void
+
+  def file_size: () -> Integer
+  def memory_size: () -> Integer
 end

--- a/sig/caotral/binary/elf/section_header.rbs
+++ b/sig/caotral/binary/elf/section_header.rbs
@@ -26,4 +26,5 @@ class Caotral::Binary::ELF::SectionHeader
   def addr: () -> Integer
   def writable?: () -> bool
   def execinstr?: () -> bool
+  def nobits?: () -> bool
 end

--- a/test/caotral/linker/integration/bss_test.rb
+++ b/test/caotral/linker/integration/bss_test.rb
@@ -28,4 +28,80 @@ class Caotral::Linker::BSSTest < Test::Unit::TestCase
     assert_equal(42, exit_code)
     assert_equal(0, handle_code)
   end
+
+  def test_initialize_zero_bss
+    path = Pathname.new("sample/assembler/bss_initialize_zero.s").to_s
+    input = "bss.o"
+    IO.popen(["as", "-o", input, path]).close
+    @inputs = [input]
+    @output = "bss"
+
+    Caotral::Linker.link!(inputs:, output:, linker: "self")
+
+    reader = Caotral::Binary::ELF::Reader.new(input: output, debug: false)
+    elf = reader.read
+    bss = elf.find_by_name(".bss")
+
+    assert_equal(:nobits, bss.header.type)
+    assert_equal(32, bss.header.size)
+
+    IO.popen(["./#{@output}"]).close
+    exit_code, handle_code = check_process($?.to_i)
+    assert_equal(42, exit_code)
+    assert_equal(0, handle_code)
+  end
+
+  def test_initialize_zero_pie_bss
+    path = Pathname.new("sample/assembler/bss_initialize_zero.s").to_s
+    input = "bss.o"
+    IO.popen(["as", "-o", input, path]).close
+    @inputs = [input]
+    @output = "bss"
+
+    Caotral::Linker.link!(inputs:, output:, linker: "self", pie: true)
+
+    reader = Caotral::Binary::ELF::Reader.new(input: output, debug: false)
+    elf = reader.read
+    bss = elf.find_by_name(".bss")
+    dynamic_symbol = elf.find_by_name(".dynsym").body.find { |sym| sym.name_string == "value" }
+
+    assert_equal(elf.index(".bss"), dynamic_symbol.shndx)
+    assert_equal(:nobits, bss.header.type)
+    assert_equal(32, bss.header.size)
+    assert_equal(bss.header.addr + 24, dynamic_symbol.value)
+
+    IO.popen(["./#{@output}"]).close
+    exit_code, handle_code = check_process($?.to_i)
+    assert_equal(42, exit_code)
+    assert_equal(0, handle_code)
+  end
+
+  def test_multiple_bss
+    @inputs = []
+    [
+      [Pathname.new("sample/assembler/bss.s").to_s, "bss.o"],
+      [Pathname.new("sample/assembler/two_bss_sections.s").to_s, "two_bss_section.o"],
+    ].each do |(path, input)|
+      IO.popen(["as", "-o", input, path]).close
+      @inputs << input
+    end
+    @output = "bss"
+
+    Caotral::Linker.link!(inputs:, output:, linker: "self", pie: true)
+
+    reader = Caotral::Binary::ELF::Reader.new(input: output, debug: false)
+    elf = reader.read
+    bss = elf.find_by_name(".bss")
+    aligned_symbol = elf.find_by_name(".symtab").body.find { |sym| sym.name_string == "aligned_value" }
+
+    assert_equal(elf.index(".bss"), aligned_symbol.shndx)
+    assert_equal(32, bss.header.size)
+    assert_equal(16, bss.header.addralign)
+    assert_equal(16, aligned_symbol.value)
+
+    IO.popen(["./#{@output}"]).close
+    exit_code, handle_code = check_process($?.to_i)
+    assert_equal(42, exit_code)
+    assert_equal(0, handle_code)
+  end
 end

--- a/test/caotral/linker/integration/bss_test.rb
+++ b/test/caotral/linker/integration/bss_test.rb
@@ -1,0 +1,31 @@
+require_relative "../../../test_suite"
+
+class Caotral::Linker::BSSTest < Test::Unit::TestCase
+  include TestProcessHelper
+  attr_reader :output, :inputs
+  def teardown
+    inputs.each { |input| File.delete(input) unless input.nil? }
+    File.delete(output) if File.exist?(output)
+  end
+  def test_bss
+    path = Pathname.new("sample/assembler/bss.s").to_s
+    input = "bss.o"
+    IO.popen(["as", "-o", input, path]).close
+    @inputs = [input]
+    @output = "bss"
+
+    Caotral::Linker.link!(inputs:, output:, linker: "self")
+
+    reader = Caotral::Binary::ELF::Reader.new(input: output, debug: false)
+    elf = reader.read
+    bss = elf.find_by_name(".bss")
+
+    assert_equal(:nobits, bss.header.type)
+    assert_equal(8, bss.header.size)
+
+    IO.popen(["./#{@output}"]).close
+    exit_code, handle_code = check_process($?.to_i)
+    assert_equal(42, exit_code)
+    assert_equal(0, handle_code)
+  end
+end

--- a/test/caotral/linker/integration/bss_test.rb
+++ b/test/caotral/linker/integration/bss_test.rb
@@ -104,4 +104,28 @@ class Caotral::Linker::BSSTest < Test::Unit::TestCase
     assert_equal(42, exit_code)
     assert_equal(0, handle_code)
   end
+
+  def test_zero_size_bss
+    @inputs = []
+    [
+      [Pathname.new("sample/assembler/empty_bss.s").to_s, "bss.o"],
+    ].each do |(path, input)|
+      IO.popen(["as", "-o", input, path]).close
+      @inputs << input
+    end
+    @output = "bss"
+
+    Caotral::Linker.link!(inputs:, output:, linker: "self")
+
+    reader = Caotral::Binary::ELF::Reader.new(input: output, debug: false)
+    elf = reader.read
+    bss = elf.find_by_name(".bss")
+    symbol = elf.find_by_name(".symtab").body.find { |sym| sym.name_string == "value" }
+
+    assert_not_nil(bss)
+    assert_equal(elf.index(".bss"), symbol.shndx)
+    assert_equal(0, bss.header.size)
+    assert_equal(8, bss.header.addralign)
+    assert_equal(0, symbol.value)
+  end
 end


### PR DESCRIPTION
## Summary

- merge non-empty input `.bss` sections into an output `SHT_NOBITS` section
- preserve the memory size of NOBITS sections without serializing zero-filled bytes
- remap symbols defined in `.bss` to their output section and accumulated section-relative offsets
- place `.bss` after file-backed allocated sections and move `.symtab`/`.strtab` after it
- add RBS declarations for NOBITS and section file/memory size helpers
- add an assembler fixture and integration test that writes to and reads from a `.bss` symbol

## Why

Unlike `.data`, `.bss` occupies memory but has no section body in the ELF file. The linker previously dropped input `.bss` sections, and the section layout assumed that every section's serialized size was also its memory size. This change introduces separate file and memory size handling so the NOBITS section header keeps its `sh_size` while the writer emits no section bytes.

## Validation

- `rake test` — 52 tests, 233 assertions, 0 failures, 0 errors, and 1 environment-dependent Ruby::Box omission
- `ruby test/caotral/linker/integration/bss_test.rb` — 5 tests, 25 assertions, 0 failures, and 0 errors
- `rake steep:check` — no type errors
- the integration fixture writes `42` to a `.bss` symbol, reads it back, and exits with status 42

## Follow-up

- account for `SHT_NOBITS` in `PT_LOAD` with `p_memsz > p_filesz`
- add coverage for initial zero filling and RW LOAD containment
- preserve per-input `.bss` alignment when merging multiple objects
